### PR TITLE
Add backend_timeout variable and GCPBackendPolicy resource

### DIFF
--- a/backend-policy.tf
+++ b/backend-policy.tf
@@ -1,0 +1,23 @@
+resource "kubernetes_manifest" "backend-policy" {
+  manifest = {
+    apiVersion = "networking.gke.io/v1"
+    kind       = "GCPBackendPolicy"
+
+    metadata = {
+      name      = local.resource_name
+      namespace = local.kubernetes_namespace
+      labels    = local.labels
+    }
+
+    spec = {
+      default = {
+        timeoutSec = var.backend_timeout
+      }
+      targetRef = {
+        group = ""
+        kind  = "Service"
+        name  = local.service_name
+      }
+    }
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -14,6 +14,12 @@ locals {
   container_port = var.app_metadata["container_port"]
 }
 
+variable "backend_timeout" {
+  description = "The backend service timeout in seconds for requests. This is the maximum time the load balancer will wait for a backend response."
+  type        = number
+  default     = 30
+}
+
 variable "enable_https" {
   description = "Enable this to serve up HTTPS traffic. Requires subdomain connection."
   type        = bool


### PR DESCRIPTION
- Add `backend_timeout` variable to configure the backend service timeout in seconds (default: 30)
- Add `GCPBackendPolicy` Kubernetes resource to apply the timeout configuration to the load balancer